### PR TITLE
feature: scaffold api document

### DIFF
--- a/crates/amicis_server/src/web/routes/api.rs
+++ b/crates/amicis_server/src/web/routes/api.rs
@@ -1,10 +1,14 @@
+use std::collections::HashMap;
 use axum::{response::IntoResponse, routing::get, Json, Router};
 use serde::Serialize;
+use crate::web::routes::ResourceType::{CorrespondenceOverview, CorrespondenceTeaser, TransmissionTeaser};
 
-use super::{health_status, HealthStatus};
+use super::{Document, health_status, HealthStatus, Link, Resource};
 
 pub fn routes() -> Router {
-    Router::new().route("/health", get(get_health))
+    Router::new()
+        .route("/health", get(get_health))
+        .route("/correspondences", get(get_correspondences))
 }
 
 #[derive(Debug, Serialize)]
@@ -15,4 +19,73 @@ struct HealthResponse {
 async fn get_health() -> impl IntoResponse {
     let status = health_status().await;
     Json(HealthResponse { status })
+}
+
+async fn get_correspondences() -> impl IntoResponse {
+    let mut correspondences = HashMap::new();
+    correspondences.insert(
+        "correspondences".to_string(),
+        vec![
+            Link{
+                rel: "item".to_string(),
+                href: "/correspondences/1".to_string(),
+                target_title: "Keeping in touch".to_string(),
+                target_type: None,
+            },
+            Link{
+                rel: "item".to_string(),
+                href: "/correspondences/2".to_string(),
+                target_title: "Amicis development".to_string(),
+                target_type: None,
+            }],
+    );
+    let mut transmissions = HashMap::new();
+    transmissions.insert(
+        "transmissions".to_string(),
+        vec![
+            Link{
+                rel: "item".to_string(),
+                href: "/transmission/d7c80354-a8a9-4a02-ac3d-da79f9b64150".to_string(),
+                target_title: "Trying this out".to_string(),
+                target_type: None,
+            },
+    ],
+    );
+    Json(Document{
+        data: Resource{
+            kind: CorrespondenceOverview,
+            uri: "/correspondences".to_string(),
+            attributes: HashMap::from([
+                ("title".to_string(), "Correspondences".to_string())
+            ]),
+            relationships: Some(correspondences),
+        },
+        included: Some(vec![
+            Resource{
+                kind: CorrespondenceTeaser,
+                uri: "/correspondences/1".to_string(),
+                attributes: HashMap::from([
+                    ("title".to_string(), "Keeping in touch".to_string()),
+                ]),
+                relationships: Some(transmissions),
+            },
+            Resource{
+                kind: CorrespondenceTeaser,
+                uri: "/correspondences/2".to_string(),
+                attributes: HashMap::from([
+                    ("title".to_string(), "Amicis development".to_string()),
+                ]),
+                relationships: None,
+            },
+            Resource{
+                kind: TransmissionTeaser,
+                uri: "/transmission/d7c80354-a8a9-4a02-ac3d-da79f9b64150".to_string(),
+                attributes: HashMap::from([
+                    ("subject".to_string(), "Trying this out".to_string()),
+                    ("body".to_string(), "Wazzup, bruh?".to_string()),
+                ]),
+                relationships: None,
+            },
+        ]),
+    })
 }

--- a/crates/amicis_server/src/web/routes/mod.rs
+++ b/crates/amicis_server/src/web/routes/mod.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter, Result};
 
-use serde::Serialize;
+use serde::{Serialize};
 
 pub mod api;
 pub mod ui;
@@ -21,6 +22,46 @@ impl Display for HealthStatus {
     }
 }
 
+#[derive(Debug, Serialize)]
+enum ResourceType {
+    CorrespondenceOverview,
+    CorrespondenceTeaser,
+    TransmissionTeaser,
+}
+
+impl Display for ResourceType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let status = match self {
+            ResourceType::CorrespondenceOverview => "correspondence:overview",
+            ResourceType::CorrespondenceTeaser => "correspondence:teaser",
+            ResourceType::TransmissionTeaser => "transmission:teaser",
+        };
+        write!(f, "{}", status)
+    }
+}
+
 async fn health_status() -> HealthStatus {
     HealthStatus::Up
+}
+
+#[derive(Debug, Serialize)]
+struct Document {
+    data: Resource,
+    included: Option<Vec<Resource>>
+}
+
+#[derive(Debug, Serialize)]
+struct Resource {
+    kind: ResourceType,
+    uri: String,
+    attributes: HashMap<String, String>,
+    relationships: Option<HashMap<String, Vec<Link>>>,
+}
+
+#[derive(Debug, Serialize, Hash, Eq, PartialEq)]
+struct Link {
+    rel: String,
+    href: String,
+    target_title: String,
+    target_type: Option<String>,
 }


### PR DESCRIPTION
This PR adds a new resource that serves the document included below. It's not as far along as I hoped, but I spent way more time trying different type-related things than I expected.

I was roughly going for a JSON:API inspired document schema, with some mostly aesthetic changes. Specifically,
- renaming the `type` member to `kind`
- renaming the `id` member to `uri`
- changing the `relationships` object into a container for link objects

I've left some comments in the data below wherever I wasn't able to achieve what I wanted due to my lack of familiarity with the type system.

I imagined this document serving as a sort of home screen, providing an overview of back-and-forths (a _correspondence_) that you're in. You might have more than one correspondence with the same person, or multiple people. Within each correspondence, you'd have a series of _transmissions_. I chose that word because I thought it'd be cool to mix media types. Maybe some transmissions would be voice, others text, others video, so I didn't like calling it a "letter", "email", or "message". Also, transmission just sounds like something you'd receive on a deep space exploration mission.

```json
{
  "data": {
    "kind": "CorrespondenceOverview", // expected this to be "correspondence:overview"
    "uri": "/correspondences",
    "attributes": {
      "title": "Correspondences"
    },
    "relationships": {
      "correspondences": [
        {
          "rel": "item",
          "href": "/correspondences/1",
          "target_title": "Keeping in touch",
          "target_type": null // expected this to be omitted, not null
        },
        {
          "rel": "item",
          "href": "/correspondences/2",
          "target_title": "Amicis development",
          "target_type": null // expected this to be omitted, not null
        }
      ]
    }
  },
  "included": [
    {
      "kind": "CorrespondenceTeaser", // expected this to be "correspondence:teaser"
      "uri": "/correspondences/1",
      "attributes": {
        "title": "Keeping in touch"
        // I wanted to have "tranmissionCount: 1" here, but could not figure out how
        // to mix strings and numbers under the "attributes" member.
      },
      "relationships": {
        "transmissions": [
          {
            "rel": "item",
            "href": "/transmission/d7c80354-a8a9-4a02-ac3d-da79f9b64150",
            "target_title": "Trying this out",
            "target_type": null // expected this to be omitted, not null
          }
        ]
      }
    },
    {
      "kind": "CorrespondenceTeaser", // expected this to be "correspondence:teaser"
      "uri": "/correspondences/2",
      "attributes": {
        "title": "Amicis development"
      },
      "relationships": null // expected this to be omitted, not null
    },
    {
      "kind": "TransmissionTeaser", // expected this to be "transmission:teaser"
      "uri": "/transmission/d7c80354-a8a9-4a02-ac3d-da79f9b64150",
      "attributes": {
        "body": "Wazzup, bruh?",
        "subject": "Trying this out. Here is some snipped content for the preview tex…"
      },
      "relationships": null // expected this to be omitted, not null
    }
  ]
}


```