### PR TITLE
feature: api document

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ version = "0.1.0"
 dependencies = [
  "amicis_core",
  "clap",
+ "json_api",
 ]
 
 [[package]]
@@ -47,12 +48,14 @@ version = "0.1.0"
 dependencies = [
  "amicis_core",
  "axum",
+ "json_api",
  "leptos",
  "rand",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -872,6 +875,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json_api"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1954,6 +1966,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
+ "rand",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = ["crates/*"]
 
 [workspace.dependencies]
 amicis_core = { path = "./crates/amicis_core" }
+json_api = { path = "./crates/json_api" }
 axum = "0.7.4"
 clap = "4.4.18"
 dirs = "5.0.1"

--- a/crates/amicis_cli/Cargo.toml
+++ b/crates/amicis_cli/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 
 [dependencies]
 amicis_core.workspace = true
+json_api.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/crates/amicis_cli/src/bin/amicis.rs
+++ b/crates/amicis_cli/src/bin/amicis.rs
@@ -1,5 +1,5 @@
 use amicis_cli::args::HelloArgs;
-use clap::Parser;
+use clap::Parser as _;
 
 fn main() {
     let args = HelloArgs::parse();

--- a/crates/amicis_cli/src/lib.rs
+++ b/crates/amicis_cli/src/lib.rs
@@ -4,11 +4,8 @@ use args::{Command, HelloArgs};
 pub mod args;
 
 pub fn run(args: HelloArgs) {
-    match args.command {
-        Some(Command::Greet { name }) => {
-            let greeting = name.greet();
-            println!("{greeting}");
-        }
-        _ => {}
+    if let Some(Command::Greet { name }) = args.command {
+        let greeting = name.greet();
+        println!("{greeting}");
     }
 }

--- a/crates/amicis_server/Cargo.toml
+++ b/crates/amicis_server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 amicis_core.workspace = true
+json_api.workspace = true
 axum = { workspace = true }
 leptos = { workspace = true, features = ["ssr"] }
 rand.workspace = true
@@ -14,3 +15,4 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
+uuid = { version = "1.7.0", features = ["fast-rng", "serde", "v4"] }

--- a/crates/amicis_server/src/web/error.rs
+++ b/crates/amicis_server/src/web/error.rs
@@ -3,4 +3,5 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum Error {}
 
+#[allow(unused)]
 pub type Result<T> = core::result::Result<T, Error>;

--- a/crates/amicis_server/src/web/mod.rs
+++ b/crates/amicis_server/src/web/mod.rs
@@ -7,7 +7,6 @@ mod error;
 mod routes;
 
 pub struct WebServer {
-    port: u16,
     listener: TcpListener,
     routes: Router,
 }
@@ -20,11 +19,7 @@ impl WebServer {
 
         let listener = TcpListener::bind(("0.0.0.0", port)).await.unwrap();
 
-        Self {
-            port,
-            listener,
-            routes,
-        }
+        Self { listener, routes }
     }
 
     pub async fn run(self) {

--- a/crates/amicis_server/src/web/routes/api.rs
+++ b/crates/amicis_server/src/web/routes/api.rs
@@ -1,14 +1,15 @@
-use std::collections::HashMap;
 use axum::{response::IntoResponse, routing::get, Json, Router};
 use serde::Serialize;
-use crate::web::routes::ResourceType::{CorrespondenceOverview, CorrespondenceTeaser, TransmissionTeaser};
+use std::collections::HashMap;
+use uuid::Uuid;
 
-use super::{Document, health_status, HealthStatus, Link, Resource};
+use super::{health_status, Document, HealthStatus, Link, Resource, ResourceType};
 
 pub fn routes() -> Router {
     Router::new()
         .route("/health", get(get_health))
         .route("/correspondences", get(get_correspondences))
+        .route("/home-example", get(get_home_screen_example))
 }
 
 #[derive(Debug, Serialize)]
@@ -26,59 +27,55 @@ async fn get_correspondences() -> impl IntoResponse {
     correspondences.insert(
         "correspondences".to_string(),
         vec![
-            Link{
+            Link {
                 rel: "item".to_string(),
                 href: "/correspondences/1".to_string(),
                 target_title: "Keeping in touch".to_string(),
                 target_type: None,
             },
-            Link{
+            Link {
                 rel: "item".to_string(),
                 href: "/correspondences/2".to_string(),
                 target_title: "Amicis development".to_string(),
                 target_type: None,
-            }],
+            },
+        ],
     );
     let mut transmissions = HashMap::new();
     transmissions.insert(
         "transmissions".to_string(),
-        vec![
-            Link{
-                rel: "item".to_string(),
-                href: "/transmission/d7c80354-a8a9-4a02-ac3d-da79f9b64150".to_string(),
-                target_title: "Trying this out".to_string(),
-                target_type: None,
-            },
-    ],
+        vec![Link {
+            rel: "item".to_string(),
+            href: "/transmission/d7c80354-a8a9-4a02-ac3d-da79f9b64150".to_string(),
+            target_title: "Trying this out".to_string(),
+            target_type: None,
+        }],
     );
-    Json(Document{
-        data: Resource{
-            kind: CorrespondenceOverview,
+    Json(Document {
+        data: Resource {
+            kind: ResourceType::CorrespondenceOverview,
             uri: "/correspondences".to_string(),
-            attributes: HashMap::from([
-                ("title".to_string(), "Correspondences".to_string())
-            ]),
+            attributes: HashMap::from([("title".to_string(), "Correspondences".to_string())]),
             relationships: Some(correspondences),
         },
         included: Some(vec![
-            Resource{
-                kind: CorrespondenceTeaser,
+            Resource {
+                kind: ResourceType::CorrespondenceTeaser,
                 uri: "/correspondences/1".to_string(),
-                attributes: HashMap::from([
-                    ("title".to_string(), "Keeping in touch".to_string()),
-                ]),
+                attributes: HashMap::from([("title".to_string(), "Keeping in touch".to_string())]),
                 relationships: Some(transmissions),
             },
-            Resource{
-                kind: CorrespondenceTeaser,
+            Resource {
+                kind: ResourceType::CorrespondenceTeaser,
                 uri: "/correspondences/2".to_string(),
-                attributes: HashMap::from([
-                    ("title".to_string(), "Amicis development".to_string()),
-                ]),
+                attributes: HashMap::from([(
+                    "title".to_string(),
+                    "Amicis development".to_string(),
+                )]),
                 relationships: None,
             },
-            Resource{
-                kind: TransmissionTeaser,
+            Resource {
+                kind: ResourceType::TransmissionTeaser,
                 uri: "/transmission/d7c80354-a8a9-4a02-ac3d-da79f9b64150".to_string(),
                 attributes: HashMap::from([
                     ("subject".to_string(), "Trying this out".to_string()),
@@ -88,4 +85,132 @@ async fn get_correspondences() -> impl IntoResponse {
             },
         ]),
     })
+}
+
+static CORRESPONDENCE_TEASER_TYPE: &str = "correspondence:teaser";
+
+#[derive(Debug, Clone)]
+struct CorrespondenceTeaser {
+    id: String,
+    title: String,
+    transmissions: Vec<TransmissionTeaser>,
+}
+
+impl CorrespondenceTeaser {
+    fn new(
+        id: impl Into<String>,
+        title: impl Into<String>,
+        transmissions: Vec<TransmissionTeaser>,
+    ) -> Self {
+        let id = id.into();
+        let title = title.into();
+        Self {
+            id,
+            title,
+            transmissions,
+        }
+    }
+}
+
+impl From<CorrespondenceTeaser> for json_api::v2::Resource {
+    fn from(value: CorrespondenceTeaser) -> Self {
+        let mut builder = json_api::v2::Resource::builder()
+            .kind(CORRESPONDENCE_TEASER_TYPE)
+            .uri(format!("/api/correspondences/{}", value.id))
+            .attribute("title", value.title)
+            .attribute("transmission_count", value.transmissions.len());
+
+        if !value.transmissions.is_empty() {
+            builder = builder.relationship(
+                "transmissions",
+                json_api::v2::Relationship::from_vec(value.transmissions),
+            )
+        }
+        builder.build()
+    }
+}
+
+impl From<CorrespondenceTeaser> for json_api::v2::RelationshipObject {
+    fn from(value: CorrespondenceTeaser) -> Self {
+        json_api::v2::RelationshipObject::builder()
+            .rel("item")
+            .href(format!("/api/correspondences/{}", value.id))
+            .extension("title", value.title)
+            .build()
+    }
+}
+
+static CORRESPONDENCE_OVERVIEW_TYPE: &str = "correspondence:overview";
+
+#[derive(Debug, Default)]
+struct CorrespondenceOverview(Vec<CorrespondenceTeaser>);
+
+impl From<CorrespondenceOverview> for json_api::v2::Resource {
+    fn from(value: CorrespondenceOverview) -> Self {
+        json_api::v2::Resource::builder()
+            .kind(CORRESPONDENCE_OVERVIEW_TYPE)
+            .uri("/api/correspondences")
+            .attribute("title", "Correspondences")
+            .relationship(
+                "correspondences",
+                json_api::v2::Relationship::from_vec(value.0),
+            )
+            .build()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TransmissionTeaser {
+    id: Uuid,
+    body: String,
+    subject: String,
+}
+
+impl TransmissionTeaser {
+    fn new(body: impl Into<String>, subject: impl AsRef<str>) -> Self {
+        let id = Uuid::new_v4();
+        let body = body.into();
+        let full_subject = subject.as_ref();
+        let subject = format!("{}...", &full_subject[..65]);
+        Self { id, body, subject }
+    }
+}
+
+impl From<TransmissionTeaser> for json_api::v2::Resource {
+    fn from(value: TransmissionTeaser) -> Self {
+        json_api::v2::Resource::builder()
+            .kind("transmission:teaser")
+            .uri(format!("/api/transmissions/{}", value.id))
+            .attribute("body", value.body)
+            .attribute("subject", value.subject)
+            .build()
+    }
+}
+
+impl From<TransmissionTeaser> for json_api::v2::RelationshipObject {
+    fn from(value: TransmissionTeaser) -> Self {
+        json_api::v2::RelationshipObject::builder()
+            .rel("item")
+            .href(format!("/api/transmissions/{}", value.id))
+            .extension("title", "Trying this out")
+            .build()
+    }
+}
+
+async fn get_home_screen_example() -> impl IntoResponse {
+    let transmission_teaser = TransmissionTeaser::new(
+        "Wazzup, bruh?",
+        "Trying this out. Here is some snipped content for the preview text. This will be cut out.",
+    );
+    let correspondence_teasers = vec![
+        CorrespondenceTeaser::new("1", "Keeping in touch", vec![transmission_teaser.clone()]),
+        CorrespondenceTeaser::new("2", "Amicis development", vec![]),
+    ];
+    let overview = CorrespondenceOverview(correspondence_teasers.clone());
+    let document = json_api::v2::Document::builder()
+        .data(overview)
+        .includes_all(correspondence_teasers)
+        .includes(transmission_teaser)
+        .build();
+    Json(document)
 }

--- a/crates/amicis_server/src/web/routes/mod.rs
+++ b/crates/amicis_server/src/web/routes/mod.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter, Result};
 
-use serde::{Serialize};
+use serde::Serialize;
 
 pub mod api;
 pub mod ui;
 
 #[derive(Debug, Serialize)]
+#[allow(unused)]
 enum HealthStatus {
     Up,
     Down,
@@ -47,7 +48,7 @@ async fn health_status() -> HealthStatus {
 #[derive(Debug, Serialize)]
 struct Document {
     data: Resource,
-    included: Option<Vec<Resource>>
+    included: Option<Vec<Resource>>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/json_api/Cargo.toml
+++ b/crates/json_api/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "json_api"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+
+[features]
+default = ["v1", "v2_prototype"]
+v1 = []
+v2_prototype = []

--- a/crates/json_api/src/lib.rs
+++ b/crates/json_api/src/lib.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "v1")]
+pub mod v1;
+
+#[cfg(feature = "v2_prototype")]
+pub mod v2;

--- a/crates/json_api/src/v1/links/mod.rs
+++ b/crates/json_api/src/v1/links/mod.rs
@@ -1,0 +1,221 @@
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct LinksObject(HashMap<String, Link>);
+
+impl Deref for LinksObject {
+    type Target = HashMap<String, Link>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for LinksObject {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+pub struct NoLinkData;
+pub struct StringLinkData(String);
+pub struct ObjectLinkData(LinkObject);
+
+pub struct LinkBuilder<T> {
+    data: T,
+}
+
+impl Default for LinkBuilder<NoLinkData> {
+    fn default() -> Self {
+        Self { data: NoLinkData }
+    }
+}
+
+impl LinkBuilder<NoLinkData> {
+    pub fn href(self, href: impl Into<String>) -> LinkBuilder<StringLinkData> {
+        let href = href.into();
+        LinkBuilder {
+            data: StringLinkData(href),
+        }
+    }
+}
+
+impl LinkBuilder<StringLinkData> {
+    pub fn rel(self, rel: impl Into<String>) -> LinkBuilder<ObjectLinkData> {
+        let rel = rel.into();
+        LinkBuilder {
+            data: ObjectLinkData(LinkObject {
+                href: self.data.0,
+                rel: Some(rel),
+                described_by: None,
+                title: None,
+                kind: None,
+                hreflang: None,
+            }),
+        }
+    }
+
+    pub fn described_by(self, link: impl Into<Link>) -> LinkBuilder<ObjectLinkData> {
+        let link = link.into();
+        LinkBuilder {
+            data: ObjectLinkData(LinkObject {
+                href: self.data.0,
+                rel: None,
+                described_by: Some(Box::new(link)),
+                title: None,
+                kind: None,
+                hreflang: None,
+            }),
+        }
+    }
+
+    pub fn title(self, title: impl Into<String>) -> LinkBuilder<ObjectLinkData> {
+        let title = title.into();
+        LinkBuilder {
+            data: ObjectLinkData(LinkObject {
+                href: self.data.0,
+                rel: None,
+                described_by: None,
+                title: Some(title),
+                kind: None,
+                hreflang: None,
+            }),
+        }
+    }
+
+    pub fn kind(self, kind: impl Into<String>) -> LinkBuilder<ObjectLinkData> {
+        let kind = kind.into();
+        LinkBuilder {
+            data: ObjectLinkData(LinkObject {
+                href: self.data.0,
+                rel: None,
+                described_by: None,
+                title: None,
+                kind: Some(kind),
+                hreflang: None,
+            }),
+        }
+    }
+
+    pub fn hreflang(self, hreflang: impl Into<String>) -> LinkBuilder<ObjectLinkData> {
+        let hreflang = hreflang.into();
+        LinkBuilder {
+            data: ObjectLinkData(LinkObject {
+                href: self.data.0,
+                rel: None,
+                described_by: None,
+                title: None,
+                kind: None,
+                hreflang: Some(hreflang),
+            }),
+        }
+    }
+
+    pub fn build(self) -> Link {
+        Link(CoreLink::String(self.data.0))
+    }
+}
+
+impl LinkBuilder<ObjectLinkData> {
+    pub fn rel(self, rel: impl Into<String>) -> Self {
+        let rel = rel.into();
+        LinkBuilder {
+            data: ObjectLinkData(LinkObject {
+                rel: Some(rel),
+                ..self.data.0
+            }),
+        }
+    }
+
+    pub fn described_by(self, link: impl Into<Link>) -> Self {
+        let link = link.into();
+        LinkBuilder {
+            data: ObjectLinkData(LinkObject {
+                described_by: Some(Box::new(link)),
+                ..self.data.0
+            }),
+        }
+    }
+
+    pub fn title(self, title: impl Into<String>) -> Self {
+        let title = title.into();
+        LinkBuilder {
+            data: ObjectLinkData(LinkObject {
+                title: Some(title),
+                ..self.data.0
+            }),
+        }
+    }
+
+    pub fn kind(self, kind: impl Into<String>) -> Self {
+        let kind = kind.into();
+        LinkBuilder {
+            data: ObjectLinkData(LinkObject {
+                kind: Some(kind),
+                ..self.data.0
+            }),
+        }
+    }
+
+    pub fn hreflang(self, hreflang: impl Into<String>) -> Self {
+        let hreflang = hreflang.into();
+        LinkBuilder {
+            data: ObjectLinkData(LinkObject {
+                hreflang: Some(hreflang),
+                ..self.data.0
+            }),
+        }
+    }
+
+    pub fn build(self) -> Link {
+        Link(CoreLink::Object(self.data.0))
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Link(CoreLink);
+
+impl Link {
+    pub fn builder() -> LinkBuilder<NoLinkData> {
+        LinkBuilder::default()
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+enum CoreLink {
+    String(String),
+    Object(LinkObject),
+}
+
+impl From<&str> for Link {
+    fn from(value: &str) -> Self {
+        Link::builder().href(value).build()
+    }
+}
+
+impl From<String> for Link {
+    fn from(value: String) -> Self {
+        Link::builder().href(value).build()
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LinkObject {
+    href: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rel: Option<String>,
+    #[serde(rename = "describedby", skip_serializing_if = "Option::is_none")]
+    described_by: Option<Box<Link>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hreflang: Option<String>,
+}

--- a/crates/json_api/src/v1/mod.rs
+++ b/crates/json_api/src/v1/mod.rs
@@ -1,0 +1,182 @@
+use serde::{Deserialize, Serialize};
+
+use self::resource::{ResourceIdentifierObject, ResourceObject};
+
+pub mod links;
+pub mod resource;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Document(CoreDocument);
+
+impl Document {
+    pub fn builder() -> DocumentBuilder<NoData, NoError> {
+        DocumentBuilder::default()
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+enum CoreDocument {
+    Data { data: CoreData },
+    Error { error: ErrorObject },
+}
+
+pub struct NoData;
+pub struct SomeData(CoreData);
+pub struct NoError;
+pub struct SomeError(ErrorObject);
+
+pub struct DocumentBuilder<D, E> {
+    data: D,
+    error: E,
+}
+
+impl DocumentBuilder<SomeData, NoError> {
+    pub fn build(self) -> Document {
+        Document(CoreDocument::Data { data: self.data.0 })
+    }
+}
+
+impl DocumentBuilder<NoData, SomeError> {
+    pub fn build(self) -> Document {
+        Document(CoreDocument::Error {
+            error: self.error.0,
+        })
+    }
+}
+
+impl DocumentBuilder<NoData, NoError> {
+    pub fn data(self, data: Data) -> DocumentBuilder<SomeData, NoError> {
+        DocumentBuilder {
+            data: SomeData(data.0),
+            error: NoError,
+        }
+    }
+
+    pub fn error(self, error: ErrorObject) -> DocumentBuilder<NoData, SomeError> {
+        DocumentBuilder {
+            data: NoData,
+            error: SomeError(error),
+        }
+    }
+}
+
+impl Default for DocumentBuilder<NoData, NoError> {
+    fn default() -> Self {
+        Self {
+            data: NoData,
+            error: NoError,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Data(CoreData);
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+enum CoreData {
+    Single(Single),
+    Collection(Collection),
+}
+
+impl Data {
+    pub fn builder() -> DataBuilder<NoSingle, NoCollection> {
+        DataBuilder::default()
+    }
+}
+
+pub struct NoSingle;
+pub struct SomeSingle(Single);
+pub struct NoCollection;
+pub struct SomeCollection(Collection);
+
+pub struct DataBuilder<S, C> {
+    single: S,
+    collection: C,
+}
+
+impl DataBuilder<NoSingle, NoCollection> {
+    pub fn resource(
+        self,
+        resource: impl Into<ResourceObject>,
+    ) -> DataBuilder<SomeSingle, NoCollection> {
+        let resource = resource.into();
+        DataBuilder {
+            single: SomeSingle(Single::Resource(resource)),
+            collection: NoCollection,
+        }
+    }
+
+    pub fn resources(
+        self,
+        resources: Vec<impl Into<ResourceObject>>,
+    ) -> DataBuilder<NoSingle, SomeCollection> {
+        let resources = resources.into_iter().map(Into::into).collect();
+        DataBuilder {
+            single: NoSingle,
+            collection: SomeCollection(Collection::Resource(resources)),
+        }
+    }
+
+    pub fn resource_identifier(
+        self,
+        resource_identifier: impl Into<ResourceIdentifierObject>,
+    ) -> DataBuilder<SomeSingle, NoCollection> {
+        let resource = resource_identifier.into();
+        DataBuilder {
+            single: SomeSingle(Single::Identifier(resource)),
+            collection: NoCollection,
+        }
+    }
+
+    pub fn resource_identifiers(
+        self,
+        resource_identifiers: Vec<impl Into<ResourceIdentifierObject>>,
+    ) -> DataBuilder<NoSingle, SomeCollection> {
+        let resource_identifiers = resource_identifiers.into_iter().map(Into::into).collect();
+        DataBuilder {
+            single: NoSingle,
+            collection: SomeCollection(Collection::Identifier(resource_identifiers)),
+        }
+    }
+}
+
+impl DataBuilder<SomeSingle, NoCollection> {
+    pub fn build(self) -> Data {
+        Data(CoreData::Single(self.single.0))
+    }
+}
+
+impl DataBuilder<NoSingle, SomeCollection> {
+    pub fn build(self) -> Data {
+        Data(CoreData::Collection(self.collection.0))
+    }
+}
+
+impl Default for DataBuilder<NoSingle, NoCollection> {
+    fn default() -> Self {
+        Self {
+            single: NoSingle,
+            collection: NoCollection,
+        }
+    }
+}
+
+// TODO: Fill this out
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ErrorObject;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+enum Single {
+    Resource(ResourceObject),
+    Identifier(ResourceIdentifierObject),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+enum Collection {
+    Resource(Vec<ResourceObject>),
+    Identifier(Vec<ResourceIdentifierObject>),
+}

--- a/crates/json_api/src/v1/resource/mod.rs
+++ b/crates/json_api/src/v1/resource/mod.rs
@@ -1,0 +1,99 @@
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::links::{Link, LinksObject};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ResourceObject {
+    #[serde(rename = "type")]
+    kind: String,
+    id: String,
+    attributes: AttributesObject,
+    #[serde(skip_serializing_if = "RelationshipsObject::is_empty")]
+    relationships: RelationshipsObject,
+    links: LinksObject,
+}
+
+impl ResourceObject {
+    pub fn new(kind: impl Into<String>, id: impl Into<String>) -> Self {
+        let kind = kind.into();
+        let id = id.into();
+        Self {
+            kind,
+            id,
+            attributes: Default::default(),
+            relationships: Default::default(),
+            links: Default::default(),
+        }
+    }
+
+    pub fn attribute(mut self, key: impl Into<String>, value: impl Into<Value>) -> Self {
+        self.attributes.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn link(mut self, name: impl Into<String>, link: impl Into<Link>) -> Self {
+        self.links.insert(name.into(), link.into());
+        self
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ResourceIdentifierObject {
+    #[serde(rename = "type")]
+    kind: String,
+    id: String,
+}
+
+impl ResourceIdentifierObject {
+    pub fn new(kind: impl Into<String>, id: impl Into<String>) -> Self {
+        let kind = kind.into();
+        let id = id.into();
+        Self { kind, id }
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct AttributesObject(HashMap<String, Value>);
+
+impl Deref for AttributesObject {
+    type Target = HashMap<String, Value>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for AttributesObject {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct RelationshipsObject(HashMap<String, RelationshipObject>);
+
+impl RelationshipsObject {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+// TODO: must contain one of "links" or "data"
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RelationshipObject {
+    // TODO: links must have either "self" or "related" link
+    links: Option<LinksObject>,
+    data: Option<ResourceLinkage>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+enum ResourceLinkage {
+    Single(Option<ResourceIdentifierObject>),
+    Many(Vec<ResourceIdentifierObject>),
+}

--- a/crates/json_api/src/v2/mod.rs
+++ b/crates/json_api/src/v2/mod.rs
@@ -1,0 +1,327 @@
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub struct NoResource;
+
+pub struct DocumentBuilder<D> {
+    data: D,
+    includes: Option<Vec<Resource>>,
+}
+
+impl Default for DocumentBuilder<NoResource> {
+    fn default() -> Self {
+        Self {
+            data: NoResource,
+            includes: None,
+        }
+    }
+}
+
+impl DocumentBuilder<NoResource> {
+    pub fn data(self, resource: impl Into<Resource>) -> DocumentBuilder<Resource> {
+        let resource = resource.into();
+        DocumentBuilder {
+            data: resource,
+            includes: self.includes,
+        }
+    }
+}
+
+impl DocumentBuilder<Resource> {
+    pub fn includes(mut self, resource: impl Into<Resource>) -> Self {
+        let resource = resource.into();
+        let includes = self.includes.get_or_insert(vec![]);
+        includes.push(resource);
+        self
+    }
+
+    pub fn includes_all(mut self, resources: Vec<impl Into<Resource>>) -> Self {
+        let resources = resources.into_iter().map(Into::into);
+        let includes = self.includes.get_or_insert(vec![]);
+        includes.extend(resources);
+        self
+    }
+
+    pub fn build(self) -> Document {
+        Document {
+            data: self.data,
+            includes: self.includes,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Document {
+    // TODO: This may need to be refined back to a Resource
+    data: Resource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    includes: Option<Vec<Resource>>,
+}
+
+impl Document {
+    pub fn builder() -> DocumentBuilder<NoResource> {
+        DocumentBuilder::default()
+    }
+}
+
+#[derive(Default)]
+pub struct NoKind;
+#[derive(Default)]
+pub struct Kind(String);
+#[derive(Default)]
+pub struct NoUri;
+#[derive(Default)]
+pub struct Uri(String);
+
+#[derive(Default)]
+pub struct ResourceBuilder<T, U> {
+    kind: T,
+    uri: U,
+    attributes: AttributesObject,
+    relationships: RelationshipsObject,
+}
+
+impl ResourceBuilder<NoKind, NoUri> {
+    fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<T, U> ResourceBuilder<T, U> {
+    pub fn attribute(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<Value>,
+    ) -> ResourceBuilder<T, U> {
+        self.attributes.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn relationship(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<Relationship>,
+    ) -> ResourceBuilder<T, U> {
+        self.relationships.insert(key.into(), value.into());
+        self
+    }
+}
+
+impl<U> ResourceBuilder<NoKind, U> {
+    pub fn kind(self, kind: impl Into<String>) -> ResourceBuilder<Kind, U> {
+        ResourceBuilder {
+            kind: Kind(kind.into()),
+            uri: self.uri,
+            attributes: self.attributes,
+            relationships: self.relationships,
+        }
+    }
+}
+
+impl<T> ResourceBuilder<T, NoUri> {
+    pub fn uri(self, uri: impl Into<String>) -> ResourceBuilder<T, Uri> {
+        ResourceBuilder {
+            kind: self.kind,
+            uri: Uri(uri.into()),
+            attributes: self.attributes,
+            relationships: self.relationships,
+        }
+    }
+}
+
+impl ResourceBuilder<Kind, Uri> {
+    pub fn build(self) -> Resource {
+        Resource {
+            kind: self.kind.0,
+            uri: self.uri.0,
+            attributes: self.attributes,
+            relationships: self.relationships,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Resource {
+    #[serde(rename = "type")]
+    kind: String,
+    uri: String,
+    #[serde(skip_serializing_if = "AttributesObject::is_empty")]
+    attributes: AttributesObject,
+    #[serde(skip_serializing_if = "RelationshipsObject::is_empty")]
+    relationships: RelationshipsObject,
+}
+
+impl Resource {
+    pub fn builder() -> ResourceBuilder<NoKind, NoUri> {
+        ResourceBuilder::new()
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct AttributesObject(HashMap<String, Value>);
+
+impl AttributesObject {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl Deref for AttributesObject {
+    type Target = HashMap<String, Value>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for AttributesObject {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct RelationshipsObject(HashMap<String, Relationship>);
+
+impl RelationshipsObject {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl Deref for RelationshipsObject {
+    type Target = HashMap<String, Relationship>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for RelationshipsObject {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Relationship(CoreRelationship);
+
+impl Relationship {
+    pub fn from_vec<T: Into<RelationshipObject>>(vec: Vec<T>) -> Self {
+        Self(CoreRelationship::Multi(
+            vec.into_iter().map(Into::into).collect(),
+        ))
+    }
+}
+
+impl<T: Into<RelationshipObject>> From<T> for Relationship {
+    fn from(value: T) -> Self {
+        Self(CoreRelationship::Single(value.into()))
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+enum CoreRelationship {
+    Single(RelationshipObject),
+    Multi(Vec<RelationshipObject>),
+}
+
+#[derive(Default)]
+pub struct NoRel;
+#[derive(Default)]
+pub struct Rel(String);
+#[derive(Default)]
+pub struct NoHref;
+#[derive(Default)]
+pub struct Href(String);
+
+#[derive(Debug, Default)]
+pub struct RelationshipObjectBuilder<R, H> {
+    rel: R,
+    href: H,
+    extensions: HashMap<String, Value>,
+}
+
+impl RelationshipObjectBuilder<NoRel, NoHref> {
+    fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<H> RelationshipObjectBuilder<NoRel, H> {
+    pub fn rel(self, rel: impl Into<String>) -> RelationshipObjectBuilder<Rel, H> {
+        RelationshipObjectBuilder {
+            rel: Rel(rel.into()),
+            href: self.href,
+            extensions: self.extensions,
+        }
+    }
+}
+
+impl<R> RelationshipObjectBuilder<R, NoHref> {
+    pub fn href(self, href: impl Into<String>) -> RelationshipObjectBuilder<R, Href> {
+        RelationshipObjectBuilder {
+            rel: self.rel,
+            href: Href(href.into()),
+            extensions: self.extensions,
+        }
+    }
+}
+
+impl<H, R> RelationshipObjectBuilder<H, R> {
+    pub fn extension(mut self, key: impl Into<String>, value: impl Into<Value>) -> Self {
+        self.extensions.insert(key.into(), value.into());
+        self
+    }
+}
+
+impl RelationshipObjectBuilder<Rel, Href> {
+    pub fn build(self) -> RelationshipObject {
+        RelationshipObject {
+            rel: self.rel.0,
+            href: self.href.0,
+            extensions: self.extensions,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RelationshipObject {
+    rel: String,
+    href: String,
+    #[serde(flatten)]
+    extensions: HashMap<String, Value>,
+}
+
+impl RelationshipObject {
+    pub fn builder() -> RelationshipObjectBuilder<NoRel, NoHref> {
+        RelationshipObjectBuilder::new()
+    }
+}
+
+// impl<T> From<Vec<T>> for RelationshipObject
+// where
+//     T: Into<RelationshipObject>,
+// {
+//     fn from(value: Vec<T>) -> Self {
+//         todo!()
+//     }
+// }
+
+// impl<T: Into<RelationshipObject>> Into<RelationshipObject> for Vec<T> {
+//     fn into(self) -> RelationshipObject {
+//         todo!()
+//     }
+// }
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ProblemDetails {
+    #[serde(rename = "type")]
+    kind: String,
+}

--- a/crates/json_api/src/v2/mod.rs
+++ b/crates/json_api/src/v2/mod.rs
@@ -57,7 +57,6 @@ impl DocumentBuilder<Resource> {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Document {
-    // TODO: This may need to be refined back to a Resource
     data: Resource,
     #[serde(skip_serializing_if = "Option::is_none")]
     includes: Option<Vec<Resource>>,
@@ -304,21 +303,6 @@ impl RelationshipObject {
         RelationshipObjectBuilder::new()
     }
 }
-
-// impl<T> From<Vec<T>> for RelationshipObject
-// where
-//     T: Into<RelationshipObject>,
-// {
-//     fn from(value: Vec<T>) -> Self {
-//         todo!()
-//     }
-// }
-
-// impl<T: Into<RelationshipObject>> Into<RelationshipObject> for Vec<T> {
-//     fn into(self) -> RelationshipObject {
-//         todo!()
-//     }
-// }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ProblemDetails {


### PR DESCRIPTION
This PR is for adding a new crate for handling the API document framework that is loosely based on the JSON:API spec.

There are two modules in the `json_api` crate. The `v1` module was my attempt at implementing the JSON:API v1 spec and is unfinished. The `v2` module is an adaptation based on the document from PR #1. It supports adding any resource type to the document, as well as relationship link objects, and it can (de)serialize the document. The ability to get resources from a document still needs to be added.

The `/api/home-example` route has a working example of adding resources to a document and returning a JSON representation of that document.

I figured that we can track the work on the API document feature on this branch.

